### PR TITLE
chore: bump version to 0.1.1 for republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-03-27
+
+### Fixed
+
+- Claude Code plugin: added `commands`, `mcpServers`, and `hooks` declarations to `plugin.json`
+- Claude Code plugin: added `matcher` to SessionStart hook for proper trigger
+- Claude Code plugin: added `/mpp-inspect`, `/mpp-scan`, `/mpp-flow` slash command skills
+
 ## [0.1.0] - 2026-03-27
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpp-inspector",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Testing and debugging toolkit for Machine Payments Protocol",
   "type": "module",
   "bin": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpp-inspector/mock-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mock MPP server for testing and demoing mpp-inspector",
   "type": "module",
   "bin": {

--- a/packages/plugin/.claude-plugin/plugin.json
+++ b/packages/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mpp-inspector",
   "description": "Inspect, debug, and test Machine Payments Protocol (HTTP 402) endpoints directly from Claude Code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "MPP Inspector Contributors",
     "url": "https://github.com/amgb20/MPP-Inspector"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpp-inspector/plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server and Claude Code plugin for Machine Payments Protocol inspection",
   "type": "module",
   "bin": {
@@ -42,7 +42,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "zod": "^3.25.23",
-    "mpp-inspector": "0.1.0"
+    "mpp-inspector": "0.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
- Bump all 3 package versions from 0.1.0 to 0.1.1
- Update plugin dependency on mpp-inspector CLI
- Update plugin.json version
- Add changelog entry for 0.1.1