### PR TITLE
fix: inline hooks in plugin.json, bump to v0.1.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpp-inspector",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Testing and debugging toolkit for Machine Payments Protocol",
   "type": "module",
   "bin": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpp-inspector/mock-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Mock MPP server for testing and demoing mpp-inspector",
   "type": "module",
   "bin": {

--- a/packages/plugin/.claude-plugin/plugin.json
+++ b/packages/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mpp-inspector",
   "description": "Inspect, debug, and test Machine Payments Protocol (HTTP 402) endpoints directly from Claude Code",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "MPP Inspector Contributors",
     "url": "https://github.com/amgb20/MPP-Inspector"
@@ -25,5 +25,18 @@
       "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"]
     }
   },
-  "hooks": "./hooks/hooks.json"
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/hooks/session-check.js\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpp-inspector/plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server and Claude Code plugin for Machine Payments Protocol inspection",
   "type": "module",
   "bin": {
@@ -42,7 +42,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "zod": "^3.25.23",
-    "mpp-inspector": "0.1.1"
+    "mpp-inspector": "0.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
Fixes hooks showing as numbered indices instead of named hooks. Inlines SessionStart hook directly in plugin.json instead of referencing ./hooks/hooks.json as a string path.